### PR TITLE
Align button 'Standard' horizontally with other buttons

### DIFF
--- a/skychart/pu_edittoolbar.lfm
+++ b/skychart/pu_edittoolbar.lfm
@@ -52,7 +52,7 @@ object f_edittoolbar: Tf_edittoolbar
     object ButtonStd: TButton
       Left = 186
       Height = 25
-      Top = 8
+      Top = 4
       Width = 75
       Caption = 'Standard'
       OnClick = ButtonStdClick


### PR DESCRIPTION
In Toolbar editor dialog, the buttons are horizontally
aligned with setting Top = 4 except the button 'Standard'
which is aligned with Top = 8. This PR makes sure the
buttons are all equally aligned with distance Top = 4

See screenshot with Top = 8 (before)
![before](https://user-images.githubusercontent.com/5285079/149023777-17b1d545-2b96-4298-be34-0700a2a34aac.png)

See screenshot with Top = 4 (after)
![after](https://user-images.githubusercontent.com/5285079/149023793-ed1df8f1-af21-4361-8d52-1ecf100ebec1.png)
.